### PR TITLE
feat: add ai content filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ node_modules
 
 # Generated files
 docs
+
+.vscode

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
+import { logger } from './logger'
 
 export interface AppConfig {
   beeApiUrls: string[]
@@ -234,7 +235,7 @@ export function getFilteringConfig({ FILTERING_CONFIG_FILE }: EnvironmentVariabl
   const NO_FILTERING: FilteringConfig = { active: false, key: '', url: '', prompt: '' }
 
   if (!FILTERING_CONFIG_FILE) {
-    //console.warn('FILTERING_CONFIG_FILE is not defined, filtering is disabled')
+    logger.warning('FILTERING_CONFIG_FILE is not defined, filtering is disabled')
 
     return NO_FILTERING
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface AppConfig {
   filteringKey: string
   filteringUrl: string
   filteringPrompt: string
+  filteringTimeout: number
 }
 
 export interface ServerConfig {
@@ -58,6 +59,7 @@ export interface FilteringConfig {
   key: string
   url: string
   prompt: string
+  timeout: number
 }
 
 export type StampsConfig = StampsConfigHardcoded | StampsConfigAutobuy | StampsConfigExtends
@@ -148,6 +150,7 @@ export function getAppConfig({
     filteringKey: filteringConfig.key,
     filteringUrl: filteringConfig.url,
     filteringPrompt: filteringConfig.prompt,
+    filteringTimeout: filteringConfig.timeout || 3000,
   }
 }
 
@@ -223,7 +226,7 @@ export function getContentConfig({ BEE_API_URLS, REUPLOAD_PERIOD }: EnvironmentV
 }
 
 export function getFilteringConfig({ FILTERING_CONFIG_FILE }: EnvironmentVariables = {}): FilteringConfig {
-  const NO_FILTERING: FilteringConfig = { active: false, key: '', url: '', prompt: '' }
+  const NO_FILTERING: FilteringConfig = { active: false, key: '', url: '', prompt: '', timeout: 3000 }
 
   if (!FILTERING_CONFIG_FILE) {
     logger.warn('FILTERING_CONFIG_FILE is not defined, filtering is disabled')

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,24 +108,15 @@ export type EnvironmentVariables = Partial<{
   FILTERING_CONFIG_FILE: string
 }>
 
-export const SUPPORTED_LEVELS = ['critical', 'error', 'warn', 'info', 'verbose', 'debug'] as const
-export type SupportedLevels = typeof SUPPORTED_LEVELS[number]
-
 export const DEFAULT_BEE_API_URL = 'http://localhost:1633'
 export const DEFAULT_HOSTNAME = 'localhost'
 export const DEFAULT_PORT = 3000
 export const DEFAULT_POSTAGE_USAGE_THRESHOLD = 0.7
 export const DEFAULT_POSTAGE_USAGE_MAX = 0.9
 export const DEFAULT_POSTAGE_REFRESH_PERIOD = 60_000
-export const DEFAULT_LOG_LEVEL = 'info'
 export const MINIMAL_EXTENDS_TTL_VALUE = 60
 export const READINESS_TIMEOUT_MS = 3000
 export const ERROR_NO_STAMP = 'No postage stamp'
-
-export const logLevel =
-  process.env.LOG_LEVEL && SUPPORTED_LEVELS.includes(process.env.LOG_LEVEL as SupportedLevels)
-    ? process.env.LOG_LEVEL
-    : DEFAULT_LOG_LEVEL
 
 export function getAppConfig({
   BEE_API_URLS,
@@ -235,7 +226,7 @@ export function getFilteringConfig({ FILTERING_CONFIG_FILE }: EnvironmentVariabl
   const NO_FILTERING: FilteringConfig = { active: false, key: '', url: '', prompt: '' }
 
   if (!FILTERING_CONFIG_FILE) {
-    logger.warning('FILTERING_CONFIG_FILE is not defined, filtering is disabled')
+    logger.warn('FILTERING_CONFIG_FILE is not defined, filtering is disabled')
 
     return NO_FILTERING
   }
@@ -247,6 +238,7 @@ export function getFilteringConfig({ FILTERING_CONFIG_FILE }: EnvironmentVariabl
     return { ...filteringConfig, active: true }
   } catch (error) {
     logger.error(`Error reading filtering config file: ${error instanceof Error ? error.message : 'Unknown error'}`)
+
     return NO_FILTERING
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
 export interface AppConfig {
   beeApiUrls: string[]
   authorization?: string
@@ -9,6 +12,10 @@ export interface AppConfig {
   exposeHashedIdentity?: boolean
   readinessCheck?: boolean
   homepage?: string
+  filteringActive: boolean
+  filteringKey: string
+  filteringUrl: string
+  filteringPrompt: string
 }
 
 export interface ServerConfig {
@@ -43,6 +50,13 @@ export interface StampsConfigAutobuy {
   usageMax: number
   ttlMin: number
   refreshPeriod: number
+}
+
+export interface FilteringConfig {
+  active: boolean
+  key: string
+  url: string
+  prompt: string
 }
 
 export type StampsConfig = StampsConfigHardcoded | StampsConfigAutobuy | StampsConfigExtends
@@ -88,6 +102,9 @@ export type EnvironmentVariables = Partial<{
 
   // Homepage
   HOMEPAGE: string
+
+  // Filtering config file
+  FILTERING_CONFIG_FILE: string
 }>
 
 export const SUPPORTED_LEVELS = ['critical', 'error', 'warn', 'info', 'verbose', 'debug'] as const
@@ -120,7 +137,10 @@ export function getAppConfig({
   EXPOSE_HASHED_IDENTITY,
   READINESS_CHECK,
   HOMEPAGE,
+  FILTERING_CONFIG_FILE,
 }: EnvironmentVariables = {}): AppConfig {
+  const filteringConfig = getFilteringConfig({ FILTERING_CONFIG_FILE })
+
   return {
     hostname: HOSTNAME || DEFAULT_HOSTNAME,
     beeApiUrls: BEE_API_URLS ? BEE_API_URLS.split(',') : [DEFAULT_BEE_API_URL],
@@ -132,6 +152,10 @@ export function getAppConfig({
     exposeHashedIdentity: EXPOSE_HASHED_IDENTITY === 'true',
     readinessCheck: READINESS_CHECK === 'true',
     homepage: HOMEPAGE,
+    filteringActive: filteringConfig.active,
+    filteringKey: filteringConfig.key,
+    filteringUrl: filteringConfig.url,
+    filteringPrompt: filteringConfig.prompt,
   }
 }
 
@@ -203,5 +227,31 @@ export function getContentConfig({ BEE_API_URLS, REUPLOAD_PERIOD }: EnvironmentV
   return {
     beeApiUrls: BEE_API_URLS ? BEE_API_URLS.split(',') : [DEFAULT_BEE_API_URL],
     refreshPeriod: Number(REUPLOAD_PERIOD),
+  }
+}
+
+export function getFilteringConfig({ FILTERING_CONFIG_FILE }: EnvironmentVariables = {}): FilteringConfig {
+  const NO_FILTERING: FilteringConfig = { active: false, key: '', url: '', prompt: '' }
+
+  if (!FILTERING_CONFIG_FILE) {
+    //console.warn('FILTERING_CONFIG_FILE is not defined, filtering is disabled')
+
+    return NO_FILTERING
+  }
+
+  try {
+    const result = readFileSync(join(__dirname, FILTERING_CONFIG_FILE), 'utf-8')
+    const filteringConfig: FilteringConfig = JSON.parse(result)
+
+    return { ...filteringConfig, active: true }
+  } catch (error) {
+    /*
+    console.error(
+      `Error reading filtering config file: ${
+        error instanceof Error ? error.message : 'Unknown error'
+      }, filtering is disabled`,
+    )
+    */
+    return NO_FILTERING
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -246,13 +246,7 @@ export function getFilteringConfig({ FILTERING_CONFIG_FILE }: EnvironmentVariabl
 
     return { ...filteringConfig, active: true }
   } catch (error) {
-    /*
-    console.error(
-      `Error reading filtering config file: ${
-        error instanceof Error ? error.message : 'Unknown error'
-      }, filtering is disabled`,
-    )
-    */
+    logger.error(`Error reading filtering config file: ${error instanceof Error ? error.message : 'Unknown error'}`)
     return NO_FILTERING
   }
 }

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -7,7 +7,7 @@ export type AIResponse = {
 
 export interface Message {
   text: string
-  messageId: string
+  messageId?: string
   threadId?: string
   parent?: string
   flagged?: boolean

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -1,3 +1,5 @@
+import { logger } from "./logger"
+
 export type AIResponse = {
   flagged: boolean
   reason: string
@@ -45,7 +47,7 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
     signal: controller.signal,
   })
     .catch((error: any) => {
-      //console.log(error)
+      logger.error('Error calling AI', error)
 
       return new Response(null, { status: 408, statusText: 'Request Timeout' })
     })
@@ -60,7 +62,7 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
     const cleanedResponse = data.result.response.replace(/```/g, '')
     retV = JSON.parse(cleanedResponse)
   } catch (error) {
-    //console.log(error)
+    logger.error('Error parsing response', error)
 
     return { flagged: false, reason: 'Error parsing response' }
   }

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -7,9 +7,9 @@ export type AIResponse = {
 
 export interface Message {
   text: string
-  threadId: string
   messageId: string
-  parent: string | null
+  threadId?: string
+  parent?: string
   flagged?: boolean
   reason?: string
 }
@@ -18,8 +18,9 @@ export interface UserMessage {
   message: Message
   timestamp: number
   username: string
-  address: string
+  address?: string
 }
+
 export async function callAI(
   prompt: string,
   userInput: string,
@@ -93,8 +94,10 @@ export async function doFiltering(
   }
   const aiResponse = await callAI(prompt, userMessage.message.text, APIUrl, key, timeout)
   userMessage.message.flagged = aiResponse.flagged
-  //userMessage.message.reason = aiResponse.reason
-  //logger.info(JSON.stringify(userMessage))
+
+  if (aiResponse.reason.length > 0) {
+    logger.warning(aiResponse.reason)
+  }
 
   return Buffer.from(JSON.stringify(userMessage))
 }

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -20,7 +20,13 @@ export interface UserMessage {
   username: string
   address: string
 }
-export async function callAI(prompt: string, userInput: string, url: string, token: string): Promise<AIResponse> {
+export async function callAI(
+  prompt: string,
+  userInput: string,
+  url: string,
+  token: string,
+  timeout: number,
+): Promise<AIResponse> {
   const requestBody = {
     messages: [
       {
@@ -35,7 +41,7 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
   }
 
   const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), 3000)
+  const timeoutId = setTimeout(() => controller.abort(), timeout)
 
   const response = await fetch(url, {
     method: 'POST',
@@ -55,6 +61,7 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
 
   if (response.status === 408) {
     logger.error('AI Request timed out')
+
     return { flagged: false, reason: 'AI Request timed out' }
   }
   let retV: AIResponse = { flagged: false, reason: '' }
@@ -71,17 +78,23 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
   return retV
 }
 
-export async function doFiltering(body: Buffer, prompt: string, APIUrl: string, key: string): Promise<Buffer> {
+export async function doFiltering(
+  body: Buffer,
+  prompt: string,
+  APIUrl: string,
+  key: string,
+  timeout: number,
+): Promise<Buffer> {
   const bodyBuffer = Buffer.from(body)
   const userMessage = JSON.parse(bodyBuffer.toString('utf8')) as UserMessage
 
   if (typeof userMessage.message === 'string') {
     userMessage.message = JSON.parse(userMessage.message) as Message
   }
-  const aiResponse = await callAI(prompt, userMessage.message.text, APIUrl, key)
+  const aiResponse = await callAI(prompt, userMessage.message.text, APIUrl, key, timeout)
   userMessage.message.flagged = aiResponse.flagged
   //userMessage.message.reason = aiResponse.reason
-  logger.debug('userMessage', userMessage)
+  //logger.info(JSON.stringify(userMessage))
 
   return Buffer.from(JSON.stringify(userMessage))
 }

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -52,7 +52,7 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
     .finally(() => clearTimeout(timeoutId))
 
   if (response.status === 408) {
-    return { flagged: true, reason: 'Request timed out' }
+    return { flagged: false, reason: 'Request timed out' }
   }
   let retV: AIResponse = { flagged: false, reason: '' }
   try {
@@ -62,7 +62,7 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
   } catch (error) {
     //console.log(error)
 
-    return { flagged: true, reason: 'Error parsing response' }
+    return { flagged: false, reason: 'Error parsing response' }
   }
 
   return retV

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -1,4 +1,4 @@
-import { logger } from "./logger"
+import { logger } from './logger'
 
 export type AIResponse = {
   flagged: boolean
@@ -68,4 +68,19 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
   }
 
   return retV
+}
+
+export async function doFiltering(body: Buffer, prompt: string, APIUrl: string, key: string): Promise<Buffer> {
+  const bodyBuffer = Buffer.from(body)
+  const userMessage = JSON.parse(bodyBuffer.toString('utf8')) as UserMessage
+
+  if (typeof userMessage.message === 'string') {
+    userMessage.message = JSON.parse(userMessage.message) as Message
+  }
+  const aiResponse = await callAI(prompt, userMessage.message.text, APIUrl, key)
+  userMessage.message.flagged = aiResponse.flagged
+  //userMessage.message.reason = aiResponse.reason
+  logger.debug('userMessage', userMessage)
+
+  return Buffer.from(JSON.stringify(userMessage))
 }

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -1,0 +1,69 @@
+export type AIResponse = {
+  flagged: boolean
+  reason: string
+}
+
+export interface Message {
+  text: string
+  threadId: string
+  messageId: string
+  parent: string | null
+  flagged?: boolean
+  reason?: string
+}
+
+export interface UserMessage {
+  message: Message
+  timestamp: number
+  username: string
+  address: string
+}
+export async function callAI(prompt: string, userInput: string, url: string, token: string): Promise<AIResponse> {
+  const requestBody = {
+    messages: [
+      {
+        role: 'system',
+        content: prompt,
+      },
+      {
+        role: 'user',
+        content: `Comment to check: ${userInput}`,
+      },
+    ],
+  }
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 3000)
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+    signal: controller.signal,
+  })
+    .catch((error: any) => {
+      //console.log(error)
+
+      return new Response(null, { status: 408, statusText: 'Request Timeout' })
+    })
+    .finally(() => clearTimeout(timeoutId))
+
+  if (response.status === 408) {
+    return { flagged: true, reason: 'Request timed out' }
+  }
+  let retV: AIResponse = { flagged: false, reason: '' }
+  try {
+    const data = await response.json()
+    const cleanedResponse = data.result.response.replace(/```/g, '')
+    retV = JSON.parse(cleanedResponse)
+  } catch (error) {
+    //console.log(error)
+
+    return { flagged: true, reason: 'Error parsing response' }
+  }
+
+  return retV
+}

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -54,7 +54,8 @@ export async function callAI(prompt: string, userInput: string, url: string, tok
     .finally(() => clearTimeout(timeoutId))
 
   if (response.status === 408) {
-    return { flagged: false, reason: 'Request timed out' }
+    logger.error('AI Request timed out')
+    return { flagged: false, reason: 'AI Request timed out' }
   }
   let retV: AIResponse = { flagged: false, reason: '' }
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,9 @@ async function main() {
   const appConfig = getAppConfig(process.env as EnvironmentVariables)
   const { hostname, port } = getServerConfig(process.env as EnvironmentVariables)
 
-  logger.debug('proxy config', appConfig)
-  logger.debug('server config', { hostname: hostname, port })
+  const { filteringKey, ...appConfigWithoutKey } = appConfig
+  logger.info('proxy config', appConfigWithoutKey)
+  logger.info('server config', { hostname: hostname, port })
 
   let app: Application
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,7 +3,14 @@ import requestStats from 'request-stats'
 import { Logform, Logger, createLogger, format, transports } from 'winston'
 
 import { Strings } from 'cafe-utility'
-import { SUPPORTED_LEVELS, SupportedLevels, logLevel } from './config'
+
+export const DEFAULT_LOG_LEVEL = 'info'
+export const SUPPORTED_LEVELS = ['critical', 'error', 'warn', 'info', 'verbose', 'debug'] as const
+export type SupportedLevels = typeof SUPPORTED_LEVELS[number]
+export const logLevel =
+  process.env.LOG_LEVEL && SUPPORTED_LEVELS.includes(process.env.LOG_LEVEL as SupportedLevels)
+    ? process.env.LOG_LEVEL
+    : DEFAULT_LOG_LEVEL
 
 const supportedLevels: Record<SupportedLevels, number> = SUPPORTED_LEVELS.reduce(
   (acc, cur, idx) => ({ ...acc, [cur]: idx }),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,7 @@ import { subdomainToBzz } from './bzz-link'
 import { logger } from './logger'
 import { StampsManager } from './stamps'
 import { getErrorMessage } from './utils'
+import { UserMessage, Message, callAI } from './filtering'
 
 export const GET_PROXY_ENDPOINTS = ['/chunks/*', '/bytes/*', '/bzz/*', '/feeds/*']
 export const POST_PROXY_ENDPOINTS = ['/chunks', '/bytes', '/bzz', '/soc/*', '/feeds/*']
@@ -27,6 +28,10 @@ interface Options {
   ensSubdomains?: boolean
   remap: Record<string, string>
   userAgents?: string[]
+  filteringActive: boolean
+  filteringKey: string
+  filteringUrl: string
+  filteringPrompt: string
 }
 
 export function createProxyEndpoints(app: Application, options: Options) {
@@ -70,6 +75,28 @@ export function createProxyEndpoints(app: Application, options: Options) {
     await fetchAndRespond('GET', req.path, req.query, req.headers, req.body, res, options)
   })
   app.post(POST_PROXY_ENDPOINTS, async (req, res) => {
+    if (options.filteringActive && req.path.startsWith('/bytes') && req.method === 'POST') {
+      const bodyBuffer = Buffer.from(req.body)
+      const userMessage = JSON.parse(bodyBuffer.toString('utf8')) as UserMessage
+
+      if (typeof userMessage.message === 'string') {
+        userMessage.message = JSON.parse(userMessage.message) as Message
+      }
+      const aiResponse = await callAI(
+        options.filteringPrompt,
+        userMessage.message.text,
+        options.filteringUrl,
+        options.filteringKey,
+      )
+      //console.log(aiResponse)
+      userMessage.message.flagged = aiResponse.flagged
+      //userMessage.message.reason = aiResponse.reason
+      //console.log(userMessage)
+
+      req.body = Buffer.from(JSON.stringify(userMessage))
+      const bodySize = Buffer.byteLength(req.body)
+      req.headers['content-length'] = bodySize.toString()
+    }
     await fetchAndRespond('POST', req.path, req.query, req.headers, req.body, res, options)
   })
 }
@@ -96,6 +123,7 @@ async function fetchAndRespond(
     if (method === 'POST' && options.stampManager) {
       headers[SWARM_STAMP_HEADER] = postageStampLB
     }
+
     let response = await axios({
       method,
       url: Strings.joinUrl(beeApiUrlLB, path) + Objects.toQueryString(query, true),
@@ -163,8 +191,8 @@ async function fetchAndRespond(
     delete response.headers['content-length']
     delete response.headers['content-encoding']
     delete response.headers['transfer-encoding']
-    delete response.headers['connection']
-    delete response.headers['etag']
+    delete response.headers.connection
+    delete response.headers.etag
     delete response.headers['last-modified']
     delete response.headers['cache-control']
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -32,6 +32,7 @@ interface Options {
   filteringKey: string
   filteringUrl: string
   filteringPrompt: string
+  filteringTimeout: number
 }
 
 export function createProxyEndpoints(app: Application, options: Options) {
@@ -83,6 +84,7 @@ export function createProxyEndpoints(app: Application, options: Options) {
           options.filteringPrompt,
           options.filteringUrl,
           options.filteringKey,
+          options.filteringTimeout,
         )
         const bodySize = Buffer.byteLength(req.body)
         req.headers['content-length'] = bodySize.toString()

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,7 @@ import { subdomainToBzz } from './bzz-link'
 import { logger } from './logger'
 import { StampsManager } from './stamps'
 import { getErrorMessage } from './utils'
-import { UserMessage, Message, callAI } from './filtering'
+import { doFiltering } from './filtering'
 
 export const GET_PROXY_ENDPOINTS = ['/chunks/*', '/bytes/*', '/bzz/*', '/feeds/*']
 export const POST_PROXY_ENDPOINTS = ['/chunks', '/bytes', '/bzz', '/soc/*', '/feeds/*']
@@ -76,26 +76,20 @@ export function createProxyEndpoints(app: Application, options: Options) {
   })
   app.post(POST_PROXY_ENDPOINTS, async (req, res) => {
     if (options.filteringActive && req.path.startsWith('/bytes') && req.method === 'POST') {
-      const bodyBuffer = Buffer.from(req.body)
-      const userMessage = JSON.parse(bodyBuffer.toString('utf8')) as UserMessage
-
-      if (typeof userMessage.message === 'string') {
-        userMessage.message = JSON.parse(userMessage.message) as Message
+      const originalBody = req.body
+      try {
+        req.body = await doFiltering(
+          Buffer.from(req.body),
+          options.filteringPrompt,
+          options.filteringUrl,
+          options.filteringKey,
+        )
+        const bodySize = Buffer.byteLength(req.body)
+        req.headers['content-length'] = bodySize.toString()
+      } catch (error) {
+        req.body = originalBody
+        logger.error(`proxy failed: ${getErrorMessage(error)}`)
       }
-      const aiResponse = await callAI(
-        options.filteringPrompt,
-        userMessage.message.text,
-        options.filteringUrl,
-        options.filteringKey,
-      )
-      //console.log(aiResponse)
-      userMessage.message.flagged = aiResponse.flagged
-      //userMessage.message.reason = aiResponse.reason
-      //console.log(userMessage)
-
-      req.body = Buffer.from(JSON.stringify(userMessage))
-      const bodySize = Buffer.byteLength(req.body)
-      req.headers['content-length'] = bodySize.toString()
     }
     await fetchAndRespond('POST', req.path, req.query, req.headers, req.body, res, options)
   })

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ export const createApp = (
     filteringKey,
     filteringUrl,
     filteringPrompt,
+    filteringTimeout,
   }: AppConfig,
   stampManager?: StampsManager,
 ): Application => {
@@ -154,6 +155,7 @@ export const createApp = (
     filteringKey,
     filteringUrl,
     filteringPrompt,
+    filteringTimeout,
   })
 
   if (homepage) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,10 @@ export const createApp = (
     exposeHashedIdentity,
     readinessCheck,
     homepage,
+    filteringActive,
+    filteringKey,
+    filteringUrl,
+    filteringPrompt,
   }: AppConfig,
   stampManager?: StampsManager,
 ): Application => {
@@ -146,6 +150,10 @@ export const createApp = (
     userAgents: (Arrays.getArgument(process.argv, 'allow-user-agents', process.env, 'ALLOW_USER_AGENTS') || '').split(
       ',',
     ),
+    filteringActive,
+    filteringKey,
+    filteringUrl,
+    filteringPrompt,
   })
 
   if (homepage) {


### PR DESCRIPTION
- New env variable: FILTERING_CONFIG_FILE
- Format of FILTERING_CONFIG_FILE:
```json
{
    "key": "<API_KEY>",
    "url": "https://api.cloudflare.com/client/v4/accounts/<ACCOUNTID>/ai/run/@cf/meta/llama-3.2-3b-instruct",
    "prompt": "You are a content moderation expert tasked with categorizing user-generated text based on the following guidelines:\\nYou catch discussions about politics in Thailand and negative comments about the Thai monarchy. Profanity and cursing are allowed.\\nYou reply with a compact, syntactically correct JSON containing the 'flagged' boolean and 'reason' string fields.",
    "timeout": 3000
}
```
- intercepted POST endpoint: `/bytes`
- added property: `flagged`
```json
{
	"message": {
		"text":"hi",
		"threadId": "m2sqydfl-7ri7vlwk7",
		"messageId": "m2sqydfl-fkk8qvxgk",
		"parent": null,
		"flagged": true
	},
	"timestamp": 1730103501441,
	"username": "Kind Circuit",
	"address": "0xbD44e0babc05ed525A078c1698E8a2fb8704B33d"
}
```