### PR TITLE
feat: use filtering config with envVARS, not filtering empty message,…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
 import { logger } from './logger'
 
 export interface AppConfig {
@@ -235,8 +233,7 @@ export function getFilteringConfig({ FILTERING_CONFIG_FILE }: EnvironmentVariabl
   }
 
   try {
-    const result = readFileSync(join(__dirname, FILTERING_CONFIG_FILE), 'utf-8')
-    const filteringConfig: FilteringConfig = JSON.parse(result)
+    const filteringConfig: FilteringConfig = JSON.parse(FILTERING_CONFIG_FILE)
 
     return { ...filteringConfig, active: true }
   } catch (error) {

--- a/src/filtering.ts
+++ b/src/filtering.ts
@@ -92,11 +92,17 @@ export async function doFiltering(
   if (typeof userMessage.message === 'string') {
     userMessage.message = JSON.parse(userMessage.message) as Message
   }
-  const aiResponse = await callAI(prompt, userMessage.message.text, APIUrl, key, timeout)
-  userMessage.message.flagged = aiResponse.flagged
+  let aiResponse: AIResponse = { flagged: false, reason: '' }
 
-  if (aiResponse.reason.length > 0) {
-    logger.warning(aiResponse.reason)
+  if (userMessage.message.text.trim().length > 0) {
+    aiResponse = await callAI(prompt, userMessage.message.text, APIUrl, key, timeout)
+    userMessage.message.flagged = aiResponse.flagged
+  } else {
+    userMessage.message.flagged = false
+  }
+
+  if (aiResponse.flagged) {
+    logger.info(`flagged: ${userMessage.message.text} -  ${aiResponse.reason}`)
   }
 
   return Buffer.from(JSON.stringify(userMessage))


### PR DESCRIPTION
- no filter_config.json file, only `FILTER_CONFIG_FILE='{\"key\": \"fFq...`
- in case of empty message AI API is not called
- if message is flagged then message and reason is logged